### PR TITLE
Support Ruby 2.7 arg syntax in callback_options

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,22 @@
+
+name: Ruby
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '2.7']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Test
+      run: |
+        gem install bundler -v "=2.3.26"
+        bundle install --jobs 4 --retry 3
+        bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -27,11 +27,11 @@ group :development do
   gem 'travis-lint', '1.7.0'
   # Can I state that I really dislike camelcased gem names?
   gem 'RedCloth', '4.2.9'
-  gem 'sqlite3', '1.3.10'
-  gem 'test-unit', '3.0.9'
+  gem 'sqlite3', '1.6.2'
+  gem 'test-unit', '3.5.7'
 
   if activerecord?
-    gem 'activerecord', '5.1.4'
+    gem 'activerecord', '~> 6.1.7'
   end
 
   if datamapper?
@@ -45,7 +45,6 @@ group :development do
     gem 'mongoid', '3.1.6'
     gem 'i18n', '0.6.1'
   else
-    # Everyone else can get the most up-to-date I18n
-    gem 'i18n', '0.7.0'
+    gem 'i18n', '1.6.0'
   end
 end

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stringex [<img src="https://codeclimate.com/github/rsl/stringex.svg" />](https://codeclimate.com/github/rsl/stringex) [<img src="https://travis-ci.org/rsl/stringex.svg?branch=master" alt="Build Status" />](https://travis-ci.org/rsl/stringex) [<img src="https://badge.fury.io/rb/stringex.svg" alt="Gem Version" />](http://badge.fury.io/rb/stringex)
+# Stringex [<img src="https://badge.fury.io/rb/stringex.svg" alt="Gem Version" />](http://badge.fury.io/rb/stringex)
 
 Some [hopefully] useful extensions to Ruby's String class. It is made up of three libraries: ActsAsUrl, Unidecoder, and StringExtensions.
 

--- a/lib/stringex/acts_as_url/adapter/base.rb
+++ b/lib/stringex/acts_as_url/adapter/base.rb
@@ -70,7 +70,11 @@ module Stringex
         end
 
         def create_callback
-          klass.send klass_callback_method, :ensure_unique_url, callback_options
+          klass.send(
+            klass_callback_method,
+            :ensure_unique_url,
+            **callback_options
+          )
         end
 
         def klass_callback_method

--- a/stringex.gemspec
+++ b/stringex.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Russell Norris".freeze]
-  s.date = "2018-11-06"
+  s.date = "2023-04-14"
   s.description = "Some [hopefully] useful extensions to Ruby's String class. Stringex is made up of three libraries: ActsAsUrl [permalink solution with better character translation], Unidecoder [Unicode to ASCII transliteration], and StringExtensions [miscellaneous helper methods for the String class].".freeze
   s.email = "rsl@luckysneaks.com".freeze
   s.extra_rdoc_files = [
@@ -274,37 +274,29 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/rsl/stringex".freeze
   s.licenses = ["MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze, "--charset".freeze, "utf-8".freeze, "--line-numbers".freeze]
-  s.rubygems_version = "2.7.3".freeze
+  s.rubygems_version = "3.3.3".freeze
   s.summary = "Some [hopefully] useful extensions to Ruby's String class".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
+  end
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<jeweler>.freeze, ["= 2.3.7"])
-      s.add_development_dependency(%q<travis-lint>.freeze, ["= 1.7.0"])
-      s.add_development_dependency(%q<RedCloth>.freeze, ["= 4.2.9"])
-      s.add_development_dependency(%q<sqlite3>.freeze, ["= 1.3.10"])
-      s.add_development_dependency(%q<test-unit>.freeze, ["= 3.0.9"])
-      s.add_development_dependency(%q<activerecord>.freeze, ["= 5.1.4"])
-      s.add_development_dependency(%q<i18n>.freeze, ["= 0.7.0"])
-    else
-      s.add_dependency(%q<jeweler>.freeze, ["= 2.3.7"])
-      s.add_dependency(%q<travis-lint>.freeze, ["= 1.7.0"])
-      s.add_dependency(%q<RedCloth>.freeze, ["= 4.2.9"])
-      s.add_dependency(%q<sqlite3>.freeze, ["= 1.3.10"])
-      s.add_dependency(%q<test-unit>.freeze, ["= 3.0.9"])
-      s.add_dependency(%q<activerecord>.freeze, ["= 5.1.4"])
-      s.add_dependency(%q<i18n>.freeze, ["= 0.7.0"])
-    end
+  if s.respond_to? :add_runtime_dependency then
+    s.add_development_dependency(%q<jeweler>.freeze, ["= 2.3.7"])
+    s.add_development_dependency(%q<travis-lint>.freeze, ["= 1.7.0"])
+    s.add_development_dependency(%q<RedCloth>.freeze, ["= 4.2.9"])
+    s.add_development_dependency(%q<sqlite3>.freeze, ["= 1.6.2"])
+    s.add_development_dependency(%q<test-unit>.freeze, ["= 3.5.7"])
+    s.add_development_dependency(%q<activerecord>.freeze, ["~> 6.1.7"])
+    s.add_development_dependency(%q<i18n>.freeze, ["= 1.6.0"])
   else
     s.add_dependency(%q<jeweler>.freeze, ["= 2.3.7"])
     s.add_dependency(%q<travis-lint>.freeze, ["= 1.7.0"])
     s.add_dependency(%q<RedCloth>.freeze, ["= 4.2.9"])
-    s.add_dependency(%q<sqlite3>.freeze, ["= 1.3.10"])
-    s.add_dependency(%q<test-unit>.freeze, ["= 3.0.9"])
-    s.add_dependency(%q<activerecord>.freeze, ["= 5.1.4"])
-    s.add_dependency(%q<i18n>.freeze, ["= 0.7.0"])
+    s.add_dependency(%q<sqlite3>.freeze, ["= 1.6.2"])
+    s.add_dependency(%q<test-unit>.freeze, ["= 3.5.7"])
+    s.add_dependency(%q<activerecord>.freeze, ["~> 6.1.7"])
+    s.add_dependency(%q<i18n>.freeze, ["= 1.6.0"])
   end
 end
 


### PR DESCRIPTION
Fixes an issue in Ruby 3 and above where the callback options cause a NoMethodError.

```ruby
Error: test_should_truncate_words_by_default(ActsAsUrlIntegrationTest)a:
  NoMethodError: undefined method `before_validation' for [:on, :create]:Array

              target.send(method, *arguments, &block)
                    ^^^^^
```

Fix in upstream is proposed here:

- https://github.com/rsl/stringex/pull/208